### PR TITLE
스일작업

### DIFF
--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/CreateFeedbackRequest.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/CreateFeedbackRequest.java
@@ -1,7 +1,8 @@
 package com.together.user.professor.feedback.DTO;
 
-import com.together.user.professor.feedback.FeedbackCategory;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 public class CreateFeedbackRequest {
@@ -11,5 +12,6 @@ public class CreateFeedbackRequest {
     private int y;
     private String text;
     private Boolean isRead;
-    private FeedbackCategory category; //카테고리 추가
+    //private FeedbackCategory category; //삭제
+    private List<Long> categoryIds; // 변경 및 추가
 }

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackCategoryDto.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackCategoryDto.java
@@ -1,0 +1,13 @@
+package com.together.user.professor.feedback.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackCategoryDto {
+    private Long id; //pk
+    private String name; //카테고리 이름
+}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackDto.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackDto.java
@@ -1,11 +1,11 @@
 package com.together.user.professor.feedback.DTO;
 
-import com.together.user.professor.feedback.FeedbackCategory;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Data
 @AllArgsConstructor
@@ -21,6 +21,7 @@ public class FeedbackDto {
     private String author;
     private LocalDateTime createdAt;
     private Boolean isRead;
-    private FeedbackCategory category; //카테고리 추가
+    //private FeedbackCategory category; //카테고리 추가
+    private Set<String> categories; // 변경: Set<String>으로 타입 수정
 
 }

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackSummaryDto.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackSummaryDto.java
@@ -1,11 +1,11 @@
 package com.together.user.professor.feedback.DTO;
 
-import com.together.user.professor.feedback.FeedbackCategory;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Data
 @AllArgsConstructor
@@ -17,5 +17,7 @@ public class FeedbackSummaryDto {
     private String text;
     private Long authorId;
     private Boolean isRead;
-    private FeedbackCategory category;
+    //private FeedbackCategory category;
+    private Set<String> categories; // 변경: Set<String>으로 타입 수정
+
 }

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackTextHistoryDto.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/DTO/FeedbackTextHistoryDto.java
@@ -1,0 +1,13 @@
+package com.together.user.professor.feedback.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class FeedbackTextHistoryDto {
+    private Long id;
+    private String text;
+    private LocalDateTime usedAt;
+}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategory.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategory.java
@@ -1,8 +1,0 @@
-package com.together.user.professor.feedback;
-
-public enum FeedbackCategory {
-    IMPROVEMENT, // 개선 제안
-    IDEA,        // 아이디어
-    COMPLIMENT,  // 칭찬
-    QUESTION     // 질문
-}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategoryEntity.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategoryEntity.java
@@ -1,0 +1,28 @@
+package com.together.user.professor.feedback;
+
+import com.together.user.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "feedback_category")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackCategoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_id")
+    private UserEntity createdBy; // 카테고리를 생성한 교수
+}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategoryRepository.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.together.user.professor.feedback;
+
+import com.together.user.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FeedbackCategoryRepository extends JpaRepository<FeedbackCategoryEntity, Long> {
+    List<FeedbackCategoryEntity> findAllByCreatedBy(UserEntity user);
+}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackEntity.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackEntity.java
@@ -12,7 +12,9 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "feedback_entity")
@@ -47,7 +49,15 @@ public class FeedbackEntity {
 
     private Boolean isRead = false;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private FeedbackCategory category;
+//    @Enumerated(EnumType.STRING)
+//    @Column(nullable = false)
+//    private FeedbackCategory category;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "feedback_selected_categories",
+            joinColumns = @JoinColumn(name = "feedback_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    private Set<FeedbackCategoryEntity> categories = new HashSet<>(); // 변경 및 추가
 }

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackTextHistoryEntity.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackTextHistoryEntity.java
@@ -1,0 +1,35 @@
+package com.together.user.professor.feedback;
+
+import com.together.user.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "feedback_text_history")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackTextHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id", nullable = false)
+    private UserEntity professor;
+
+    @Column(nullable = false, length = 1000)
+    private String text;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime usedAt;
+}

--- a/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackTextHistoryRepository.java
+++ b/backEnd/together/src/main/java/com/together/user/professor/feedback/FeedbackTextHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.together.user.professor.feedback;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FeedbackTextHistoryRepository extends JpaRepository<FeedbackTextHistoryEntity, Long> {
+    List<FeedbackTextHistoryEntity> findByProfessor_UserIdOrderByUsedAtDesc(Long professorId);
+    Optional<FeedbackTextHistoryEntity> findByProfessor_UserIdAndText(Long professorId, String text);
+}


### PR DESCRIPTION
1. 피드백 내용 재사용 (히스토리 기능) 1.1 교수가 작성한 피드백 내용을 저장하는 FeedbackTextHistory 테이블 추가. 1.2 피드백 생성 시 자동으로 내용을 히스토리에 저장/업데이트.
1.3 내용 히스토리 조회를 위한 GET /feedbacks/history API 엔드포인트 구현.

2. 교수에 의한 동적 카테고리 관리 2.1 기존에 Enum으로 고정되었던 카테고리를 DB에서 관리하도록 FeedbackCategory 엔티티로 변경. 2.2 교수가 카테고리를 추가, 조회, 수정, 삭제할 수 있는 CRUD API 구현

3. 카테고리 다중 선택 기능 : 피드백 생성(POST /feedbacks/create) 요청 시, 단일 ID가 아닌 ID 배열(categoryIds: [1, 2, ...])을 받도록 수정.